### PR TITLE
Fixed bug on getMatchStatus

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -21,7 +21,8 @@ export enum MatchStatus {
   Postponed = 'Postponed',
   Over = 'Over',
   Scheduled = 'Scheduled',
-  Deleted = 'Deleted'
+  Deleted = 'Deleted',
+  Notfound = 'NotFound'
 }
 
 export interface Demo {
@@ -175,12 +176,19 @@ function getMatchStatus($: HLTVPage): MatchStatus {
   switch ($('.countdown').trimText()) {
     case 'LIVE':
       status = MatchStatus.Live
+      break
     case 'Match postponed':
       status = MatchStatus.Postponed
+      break
     case 'Match deleted':
       status = MatchStatus.Deleted
+      break
     case 'Match over':
       status = MatchStatus.Over
+      break
+    default:
+      status = MatchStatus.Notfound
+      break
   }
 
   return status


### PR DESCRIPTION
Fixed bug on switch case by func getMatchStatus, need to add command break for when find value on 'case' get out of switch. By the way, i added a default value when not find any value on switch case.